### PR TITLE
Fix mobile nav visibility on large screens

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -244,6 +244,10 @@ body {
     }
     .modal-x:focus, .close-modal:focus { outline: 2px solid var(--clr-accent); }
     /* --- FABs & Mobile --- */
+    .mobile-accordion-nav {
+      display: none;
+    }
+
     .fab-stack {
       position: fixed;
       bottom: 15px;


### PR DESCRIPTION
## Summary
- hide the mobile accordion nav by default

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ffada08d4832bab62b26f9969805f