### PR TITLE
Switch join/contact to links

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,14 +32,14 @@
   </div>
   <!-- DESKTOP FABs -->
   <div class="fab-stack">
-    <button class="fab-btn" id="fab-join" title="Join Us"><i class="fa-thin fa-user-plus"></i></button>
-    <button class="fab-btn" id="fab-contact" title="Contact Us"><i class="fa-thin fa-envelope"></i></button>
+    <a class="fab-btn" id="fab-join" href="fabs/join.html" title="Join Us"><i class="fa-thin fa-user-plus"></i></a>
+    <a class="fab-btn" id="fab-contact" href="fabs/contact.html" title="Contact Us"><i class="fa-thin fa-envelope"></i></a>
     <button class="fab-btn" id="fab-chat" title="Chatbot"><i class="fa-thin fa-comment-alt"></i></button>
   </div>
   <!-- MOBILE ACCORDION NAV -->
   <div class="mobile-accordion-nav">
-    <button class="mobile-accordion-btn" id="mobile-fab-join" title="Join Us"><i class="fa-thin fa-user-plus"></i></button>
-    <button class="mobile-accordion-btn" id="mobile-fab-contact" title="Contact Us"><i class="fa-thin fa-envelope"></i></button>
+    <a class="mobile-accordion-btn" id="mobile-fab-join" href="fabs/join.html" title="Join Us"><i class="fa-thin fa-user-plus"></i></a>
+    <a class="mobile-accordion-btn" id="mobile-fab-contact" href="fabs/contact.html" title="Contact Us"><i class="fa-thin fa-envelope"></i></a>
     <button class="mobile-accordion-btn" id="mobile-fab-chat" title="Chatbot"><i class="fa-thin fa-comment-alt"></i></button>
     <button class="mobile-accordion-btn" id="mobile-fab-services" title="Services"><i class="fa-thin fa-cogs"></i></button>
     <div class="accordion-panel" id="mobile-panel-services">

--- a/js/main.js
+++ b/js/main.js
@@ -227,14 +227,10 @@
     }
     // --- FAB HANDLERS ---
     function openContactModal() {
-      let root = document.getElementById('modal-root');
-      if (root.querySelector('.modal-contact')) { root.innerHTML = ''; return; }
-      showModal('contact');
+      window.location.href = 'fabs/contact.html';
     }
     function openJoinModal() {
-      let root = document.getElementById('modal-root');
-      if (root.querySelector('.modal-join')) { root.innerHTML = ''; return; }
-      showModal('join');
+      window.location.href = 'fabs/join.html';
     }
     function openChatbot() {
       let existing = document.getElementById('chatbot-modal-backdrop');
@@ -252,11 +248,7 @@
       makeDraggable(chatbotCont);
     }
     document.getElementById('fab-chat').onclick = openChatbot;
-    document.getElementById('fab-join').onclick = openJoinModal;
-    document.getElementById('fab-contact').onclick = openContactModal;
     document.getElementById('mobile-fab-chat').onclick = openChatbot;
-    document.getElementById('mobile-fab-join').onclick = openJoinModal;
-    document.getElementById('mobile-fab-contact').onclick = openContactModal;
     // Accordion Services
     document.getElementById('mobile-fab-services').onclick = function() {
       document.getElementById('mobile-panel-services').classList.toggle('active');


### PR DESCRIPTION
## Summary
- swap Join & Contact FABs to `<a>` tags
- update mobile accordion Join/Contact to `<a>` tags
- direct Join and Contact functions to navigate instead of opening modals
- drop unused event handlers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687ffb202588832b93a7bcb719395e8e