### PR TITLE
Add Home links to forms and adjust responsive width

### DIFF
--- a/fabs/contact.html
+++ b/fabs/contact.html
@@ -20,6 +20,7 @@
     background: var(--clr-bg);
     color: var(--clr-tx);
     margin: 0; padding: 1rem;
+    width: 80%;
     max-width: 600px;
     margin-left: auto;
     margin-right: auto;
@@ -87,6 +88,7 @@
 </head>
 <body>
   <h1>Contact Us</h1>
+  <a href="../index.html">Home</a>
   <form id="contactForm" autocomplete="off">
     <div class="form-row">
       <div class="form-cell">
@@ -134,6 +136,7 @@
 
     <div class="modal-footer">
       <button type="submit" class="submit-btn">Send</button>
+      <a href="../index.html" style="margin-left:1rem;">Home</a>
     </div>
   </form>
 

--- a/fabs/join.html
+++ b/fabs/join.html
@@ -21,6 +21,7 @@
     background: var(--clr-bg);
     color: var(--clr-tx);
     margin: 0; padding: 1rem;
+    width: 80%;
     max-width: 600px;
     margin-left: auto;
     margin-right: auto;
@@ -135,6 +136,7 @@
 </head>
 <body>
   <h1>Join Us</h1>
+  <a href="../index.html">Home</a>
   <form id="joinForm" autocomplete="off" novalidate>
     <div class="form-pairs">
       <div>
@@ -235,6 +237,7 @@
 
     <div class="modal-footer">
       <button type="submit" class="submit-btn">Submit</button>
+      <a href="../index.html" style="margin-left:1rem;">Home</a>
     </div>
   </form>
 


### PR DESCRIPTION
## Summary
- make join.html and contact.html forms responsive using a fixed width percentage
- add "Home" links above the form and inside the modal footer

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68802f4b2590832ba29ed3b5e60e5c0a