### PR TITLE
Add basic PWA files

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v6.0.0-beta1/css/all.css">
   <link rel="stylesheet" href="css/global.css">
   <link rel="stylesheet" href="css/adaptablescreens.css" media="(max-width: 900px)">
+  <link rel="manifest" href="manifest.json">
 </head>
 <body>
   <!-- NAV -->
@@ -58,5 +59,12 @@
   </footer>
   <script src="js/main.js"></script>
   <script src="js/connector.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/sw.js');
+      });
+    }
+  </script>
 </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,18 @@
+{
+  "name": "OPS Unified Portal",
+  "short_name": "OPS",
+  "start_url": "/index.html",
+  "display": "standalone",
+  "icons": [
+    {
+      "src": "https://placehold.co/192x192?text=OPS",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "https://placehold.co/512x512?text=OPS",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://example.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/</loc></url>
+  <url><loc>https://example.com/bot/chatbot.html</loc></url>
+  <url><loc>https://example.com/fabs/contact.html</loc></url>
+  <url><loc>https://example.com/fabs/join.html</loc></url>
+  <url><loc>https://example.com/modals/businessoperations.html</loc></url>
+  <url><loc>https://example.com/modals/contactcenter.html</loc></url>
+  <url><loc>https://example.com/modals/itsupport.html</loc></url>
+  <url><loc>https://example.com/modals/professionals.html</loc></url>
+  <url><loc>https://example.com/services/business.html</loc></url>
+  <url><loc>https://example.com/services/contactcenter.html</loc></url>
+  <url><loc>https://example.com/services/itsupport.html</loc></url>
+  <url><loc>https://example.com/services/professionals.html</loc></url>
+</urlset>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,18 @@
+// Placeholder service worker with basic caching strategies
+const CACHE_NAME = 'ops-cache-v1';
+const PRECACHE_URLS = [
+  '/',
+  '/index.html'
+];
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(PRECACHE_URLS))
+  );
+});
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => {
+      return response || fetch(event.request);
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add a default PWA manifest
- create placeholder service worker
- generate robots.txt and sitemap.xml
- register service worker and manifest in the main page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68802f734694832baaa908abaef4212d