### PR TITLE
Improve layout responsiveness

### DIFF
--- a/css/adaptablescreens.css
+++ b/css/adaptablescreens.css
@@ -85,4 +85,18 @@
 @media (max-width: 900px) {
   .fab-stack { display: none; }
   .mobile-accordion-nav { display: block; }
+  .grid-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 80%;
+    margin: 80px auto 0;
+  }
+  .grid-container .card {
+    width: 100%;
+  }
+  .ops-modal, .modal-content {
+    top: 50%;
+    transform: translate(-50%, -50%);
+  }
 }

--- a/css/global.css
+++ b/css/global.css
@@ -103,12 +103,11 @@ body {
     /* CARDS */
 .grid-container {
   width: min(75rem, 100%);
-  margin-inline: auto;
-  margin-left: 70px;
-  margin-top: 150px;
+  margin: 150px auto 0;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
   gap: 1.5rem;
+  justify-content: center;
 }
     .card {
       --grad: var(--clr-primary), var(--clr-accent);
@@ -188,10 +187,10 @@ body {
       border-radius: 2rem;
       box-shadow: 0 6px 60px #5e24bb25, 0 0 0 2px #fff1;
       padding: 2.1rem 2.2rem 1.3rem 2.2rem;
-      position: absolute;
+      position: fixed;
       left: 50%;
-      top: 250px;
-      transform: translate(-50%, 0);
+      top: 50%;
+      transform: translate(-50%, -50%);
       transition: box-shadow .17s;
       cursor: default;
       z-index: 2222;


### PR DESCRIPTION
## Summary
- center the cards grid on large screens
- center modal popups on screen
- stack cards vertically on mobile

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6880c81dd1d8832b822548fab35396ce