### PR TITLE
Add SRI hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Neo OPS
+
+This repository includes a simple chatbot and static assets.
+
+## Subresource Integrity
+
+Subresource Integrity (SRI) hashes are used for external resources to ensure the files have not been tampered with. The SHA-384 hashes were generated using OpenSSL:
+
+```bash
+openssl dgst -sha384 -binary path/to/file | openssl base64 -A
+```
+
+The resulting base64 string is added as the value for the `integrity` attribute.
+
+## Files
+- `bot/app.js`
+- `bot/chatbot.html`
+

--- a/bot/chatbot.html
+++ b/bot/chatbot.html
@@ -45,6 +45,8 @@
     </label>
   </div>
 </div>
-<script src="app.js"></script>
+<script src="app.js"
+        integrity="sha384-iN8j0v/FTQadFREqEAqazTeZkNjvuoG0rOeP27KnW00592cI9hRCJs9qnVrex5r7"
+        crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- document how to generate SHA-384 SRI hashes
- add integrity and crossorigin attributes for the chatbot script

## Testing
- `openssl dgst -sha384 -binary bot/app.js | openssl base64 -A`


------
https://chatgpt.com/codex/tasks/task_e_6880f2a450a0832b94d0eac556c23b2e