### PR TITLE
Fix chatbot iframe layout

### DIFF
--- a/bot/style.css
+++ b/bot/style.css
@@ -8,36 +8,38 @@
   --clr-tx:#333333;
   --clr-tx-dark:#f0f0f0;
 }
+html,body{
+  height:100%;
+}
 body{
   margin:0;
   display:flex;
   align-items:center;
   justify-content:center;
-  height:100vh;
+  min-height:100%;
   font-family:'Segoe UI',Arial,sans-serif;
-  background:var(--clr-bg);
+  background:transparent;
   color:var(--clr-tx);
   transition:background .3s,color .3s;
 }
-body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
+body.dark{
+  --clr-bg:var(--clr-bg-dark);
+  --clr-tx:var(--clr-tx-dark);
+  background:transparent;
+}
 
 /* ---------- CHATBOT ---------- */
 #chatbot-container{
-  position:absolute;
-  width:350px;
-  height:580px;
-  background:#251541;
-  border:2px solid var(--clr-accent);
-  border-radius:18px;
-  box-shadow:0 8px 32px rgba(0,0,0,0.4);
+  position:static;
+  width:100%;
+  height:100%;
+  background:transparent;
+  border:none;
+  border-radius:0;
+  box-shadow:none;
   display:flex;
   flex-direction:column;
   overflow:hidden;
-  resize:both;
-  min-width:300px;
-  min-height:400px;
-  max-width:95vw;
-  max-height:95vh;
 }
 #chatbot-header{
   display:flex;
@@ -126,26 +128,14 @@ button.ctrl{background:transparent;border:none;color:inherit;padding:0;}
 /* ---------- RESPONSIVE STYLES ---------- */
 @media(max-width:768px){
   #chatbot-container{
-    width:90vw;
-    height:80vh;
-    max-width:400px;
-    max-height:600px;
-    top:50%;
-    left:50%;
-    transform:translate(-50%,-50%);
+    width:100%;
+    height:100%;
   }
 }
 @media(max-width:480px){
   #chatbot-container{
-    width:100vw;
-    height:100vh;
-    border-radius:0;
-    border:none;
-    top:0;
-    left:0;
-    transform:none;
-    max-width:100%;
-    max-height:100%;
+    width:100%;
+    height:100%;
   }
   #chatbot-header{cursor:default;}
 }


### PR DESCRIPTION
## Summary
- adjust `bot/style.css` so the iframe page is transparent and does not force full-screen
- ensure responsive rules keep the iframe at 100% of its container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881003ef65c832bac4c71d363f08b64