### PR TITLE
Integrate postMessage close action

### DIFF
--- a/bot/app.js
+++ b/bot/app.js
@@ -27,12 +27,12 @@ window.addEventListener('message', event => {
   }
 });
 
-// Close handler with fallback
-closeCtrl.addEventListener('click', () => {
-  if (history.length > 1) history.back();
-  else window.location.href = '/';
-});
-window.addEventListener('keydown', e => { if (e.key === 'Escape') closeCtrl.click(); });
+// Close handler via parent message
+function closeChatbot() {
+  window.parent.postMessage({ type: 'closeChatbot' }, '*');
+}
+closeCtrl.addEventListener('click', closeChatbot);
+window.addEventListener('keydown', e => { if (e.key === 'Escape') closeChatbot(); });
 
 
 /* === Chatbot Core === */

--- a/js/main.js
+++ b/js/main.js
@@ -247,6 +247,13 @@
     }
     document.getElementById('fab-chat').onclick = openChatbot;
     document.getElementById('mobile-fab-chat').onclick = openChatbot;
+    // Listen for close requests from chatbot iframe
+    window.addEventListener('message', event => {
+      if (event.data && event.data.type === 'closeChatbot') {
+        const cont = document.getElementById('chatbot-container');
+        if (cont) cont.remove();
+      }
+    });
     // Accordion Services
     document.getElementById('mobile-fab-services').onclick = function() {
       document.getElementById('mobile-panel-services').classList.toggle('active');


### PR DESCRIPTION
## Summary
- replace close handler in bot/app.js to use postMessage
- listen for `closeChatbot` message in main.js

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6881004857c8832bbcc2c933d9158338