### PR TITLE
Add icons to join, contact, and modal pages

### DIFF
--- a/fabs/contact.html
+++ b/fabs/contact.html
@@ -4,6 +4,13 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <title>Contact Us - OPS • Chattia</title>
+<link
+  rel="stylesheet"
+  href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+  integrity="sha512-yHmh25n3xRh+2SmcvCyNMPIPqYvHv0JAS+oItFR0FoRcvMff9raM6vG+VubymQ9d0ERGLQHdXT9V2+IHX2+Fdg=="
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer"
+/>
 <style>
   :root {
     --clr-primary: #00c4ff;
@@ -158,7 +165,7 @@
 <body>
   <header class="top-header">
     <a href="../index.html" class="close-btn" title="Exit">&times;</a>
-    <h1>Contact Us</h1>
+    <h1><i class="fa fa-envelope" aria-hidden="true"></i> Contact Us</h1>
     <div class="btn-stack">
       <button class="toggle-btn" id="langToggle">ES</button>
       <button class="toggle-btn" id="themeToggle">Dark</button>

--- a/fabs/join.html
+++ b/fabs/join.html
@@ -4,6 +4,13 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <title>Join Us - OPS • Chattia</title>
+<link
+  rel="stylesheet"
+  href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+  integrity="sha512-yHmh25n3xRh+2SmcvCyNMPIPqYvHv0JAS+oItFR0FoRcvMff9raM6vG+VubymQ9d0ERGLQHdXT9V2+IHX2+Fdg=="
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer"
+/>
 <style>
   :root {
     --clr-primary: #00c4ff;
@@ -206,7 +213,7 @@
 <body>
   <header class="top-header">
     <a href="../index.html" class="close-btn" title="Exit">&times;</a>
-    <h1>Join Us</h1>
+    <h1><i class="fa fa-user-plus" aria-hidden="true"></i> Join Us</h1>
     <div class="btn-stack">
       <button class="toggle-btn" id="langToggle">ES</button>
       <button class="toggle-btn" id="themeToggle">Dark</button>

--- a/js/main.js
+++ b/js/main.js
@@ -222,7 +222,7 @@
           <div class="modal-actions">
             <a class="modal-btn" href="${data.learn}" target="_blank" rel="noopener noreferrer">${lang==="en"?"Learn More":"Más Información"}</a>
             <button class="modal-btn" onclick="alert('Integrate with chatbot')">${lang==="en"?"Ask Chattia":"Preguntar Chattia"}</button>
-            <button class="modal-btn cta" id="modal-contact-btn">${lang==="en"?"Contact Us":"Contáctanos"}</button>
+            <button class="modal-btn cta" id="modal-contact-btn"><i class="fa fa-envelope" aria-hidden="true"></i> ${lang==="en"?"Contact Us":"Contáctanos"}</button>
             <button class="modal-btn" id="cancel-btn">${lang==="en"?"Cancel":"Cancelar"}</button>
           </div>
         </div>`;
@@ -358,7 +358,7 @@
       return `
       <div class="modal-content" tabindex="-1" role="dialog" aria-modal="true">
         <div class="modal-header">
-          <h3>${lang==="en"?"Join Us":"Únete a Nosotros"}</h3>
+          <h3><i class="fa fa-user-plus" aria-hidden="true"></i> ${lang==="en"?"Join Us":"Únete a Nosotros"}</h3>
           <button class="close-modal" aria-label="Close">&times;</button>
         </div>
         <form id="join-form">
@@ -387,7 +387,7 @@
       return `
       <div class="modal-content" tabindex="-1" role="dialog" aria-modal="true">
         <div class="modal-header">
-          <h3>${lang==="en"?"Contact Us":"Contáctenos"}</h3>
+          <h3><i class="fa fa-envelope" aria-hidden="true"></i> ${lang==="en"?"Contact Us":"Contáctenos"}</h3>
           <button class="close-modal" aria-label="Close">&times;</button>
         </div>
         <form id="contact-form">

--- a/modals/businessoperations.html
+++ b/modals/businessoperations.html
@@ -4,6 +4,13 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Business Operations - OPS Modal</title>
+<link
+  rel="stylesheet"
+  href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+  integrity="sha512-yHmh25n3xRh+2SmcvCyNMPIPqYvHv0JAS+oItFR0FoRcvMff9raM6vG+VubymQ9d0ERGLQHdXT9V2+IHX2+Fdg=="
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer"
+/>
 
 <style>
   :root {
@@ -155,7 +162,7 @@
       <div class="modal-actions">
         <a class="modal-btn" href="../services/business.html" target="_blank" rel="noopener noreferrer">Learn More</a>
         <button class="modal-btn" id="ask-chattia-btn">Ask Chattia</button>
-        <button class="modal-btn cta" id="contact-us-btn">Contact Us</button>
+        <button class="modal-btn cta" id="contact-us-btn"><i class="fa fa-envelope" aria-hidden="true"></i> Contact Us</button>
         <button class="modal-btn cancel-btn">Cancel</button>
       </div>
     </div>

--- a/modals/contactcenter.html
+++ b/modals/contactcenter.html
@@ -4,6 +4,13 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Contact Center - OPS Modal</title>
+<link
+  rel="stylesheet"
+  href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+  integrity="sha512-yHmh25n3xRh+2SmcvCyNMPIPqYvHv0JAS+oItFR0FoRcvMff9raM6vG+VubymQ9d0ERGLQHdXT9V2+IHX2+Fdg=="
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer"
+/>
 
 <style>
   :root {
@@ -155,7 +162,7 @@
       <div class="modal-actions">
         <a class="modal-btn" href="../services/contactcenter.html" target="_blank" rel="noopener noreferrer">Learn More</a>
         <button class="modal-btn" id="ask-chattia-btn">Ask Chattia</button>
-        <button class="modal-btn cta" id="contact-us-btn">Contact Us</button>
+        <button class="modal-btn cta" id="contact-us-btn"><i class="fa fa-envelope" aria-hidden="true"></i> Contact Us</button>
         <button class="modal-btn cancel-btn">Cancel</button>
       </div>
     </div>

--- a/modals/itsupport.html
+++ b/modals/itsupport.html
@@ -4,6 +4,13 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>IT Support - OPS Modal</title>
+<link
+  rel="stylesheet"
+  href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+  integrity="sha512-yHmh25n3xRh+2SmcvCyNMPIPqYvHv0JAS+oItFR0FoRcvMff9raM6vG+VubymQ9d0ERGLQHdXT9V2+IHX2+Fdg=="
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer"
+/>
 
 <style>
   :root {
@@ -155,7 +162,7 @@
       <div class="modal-actions">
         <a class="modal-btn" href="../services/itsupport.html" target="_blank" rel="noopener noreferrer">Learn More</a>
         <button class="modal-btn" id="ask-chattia-btn">Ask Chattia</button>
-        <button class="modal-btn cta" id="contact-us-btn">Contact Us</button>
+        <button class="modal-btn cta" id="contact-us-btn"><i class="fa fa-envelope" aria-hidden="true"></i> Contact Us</button>
         <button class="modal-btn cancel-btn">Cancel</button>
       </div>
     </div>

--- a/modals/professionals.html
+++ b/modals/professionals.html
@@ -4,6 +4,13 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Professionals - OPS Modal</title>
+<link
+  rel="stylesheet"
+  href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+  integrity="sha512-yHmh25n3xRh+2SmcvCyNMPIPqYvHv0JAS+oItFR0FoRcvMff9raM6vG+VubymQ9d0ERGLQHdXT9V2+IHX2+Fdg=="
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer"
+/>
 
 <style>
   :root {
@@ -156,7 +163,7 @@
       <div class="modal-actions">
         <a class="modal-btn" href="../services/professionals.html" target="_blank" rel="noopener noreferrer">Learn More</a>
         <button class="modal-btn" id="ask-chattia-btn">Ask Chattia</button>
-        <button class="modal-btn cta" id="contact-us-btn">Contact Us</button>
+        <button class="modal-btn cta" id="contact-us-btn"><i class="fa fa-envelope" aria-hidden="true"></i> Contact Us</button>
         <button class="modal-btn cancel-btn">Cancel</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- load Font Awesome on join and contact FAB pages
- decorate Join Us and Contact Us headers with icons
- show icons in Join modal, Contact modal, and service CTA buttons
- enable Font Awesome inside service modal pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68812983cde0832ba55287981d8ca4f9