### PR TITLE
Add i18n data attributes and link updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,10 +16,10 @@
   <nav class="ops-nav" aria-label="OPS Navigation">
     <span class="ops-logo">OPS</span>
     <div class="nav-links">
-      <a href="services/business.html">Business Operations</a>
-      <a href="services/contactcenter.html">Contact Center</a>
-      <a href="services/itsupport.html">IT Support</a>
-      <a href="services/professionals.html">Professionals</a>
+      <a href="services/business.html" data-en="Business Operations" data-es="Operaciones Empresariales">Business Operations</a>
+      <a href="services/contactcenter.html" data-en="Contact Center" data-es="Centro de Contacto">Contact Center</a>
+      <a href="services/itsupport.html" data-en="IT Support" data-es="Soporte IT">IT Support</a>
+      <a href="services/professionals.html" data-en="Professionals" data-es="Profesionales">Professionals</a>
     </div>
     <div class="toggles">
       <button class="toggle-btn" id="lang-toggle">ES</button>
@@ -46,10 +46,10 @@
     <button class="mobile-accordion-btn" id="mobile-fab-chat" title="Chatbot"><i class="fa fa-comment"></i></button>
     <button class="mobile-accordion-btn" id="mobile-fab-services" title="Services"><i class="fa-thin fa-cogs"></i></button>
     <div class="accordion-panel" id="mobile-panel-services">
-      <a href="services/business.html">Business Operations</a>
-      <a href="services/contactcenter.html">Contact Center</a>
-      <a href="services/itsupport.html">IT Support</a>
-      <a href="services/professionals.html">Professionals</a>
+      <a href="services/business.html" data-en="Business Operations" data-es="Operaciones Empresariales">Business Operations</a>
+      <a href="services/contactcenter.html" data-en="Contact Center" data-es="Centro de Contacto">Contact Center</a>
+      <a href="services/itsupport.html" data-en="IT Support" data-es="Soporte IT">IT Support</a>
+      <a href="services/professionals.html" data-en="Professionals" data-es="Profesionales">Professionals</a>
       <button id="mobile-fab-home" style="margin-top:0.8em;"><i class="fa-thin fa-home"></i> Home</button>
       <button id="mobile-lang-toggle" style="margin-top:0.8em;">ES</button>
       <button id="mobile-theme-toggle">Dark</button>

--- a/js/main.js
+++ b/js/main.js
@@ -283,6 +283,11 @@
         }
       }, true);
     }
+    function updateNavLinkTexts(){
+      document.querySelectorAll('a[data-en][data-es]').forEach(a=>{
+        a.textContent = lang === 'en' ? a.getAttribute('data-en') : a.getAttribute('data-es');
+      });
+    }
     // Language/Theme (propagate)
     function setLang(l) {
       lang = l;
@@ -290,6 +295,7 @@
       document.documentElement.setAttribute('lang', lang);
       localStorage.setItem('ops-lang', l);
       connector.emit('langChange', l);
+      updateNavLinkTexts();
       let modalRoot = document.getElementById('modal-root');
       if(modalRoot) modalRoot.innerHTML='';
     }


### PR DESCRIPTION
## Summary
- add `data-en` and `data-es` attributes to nav links
- update `setLang()` to refresh link text for both desktop and mobile navs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68819a9b9c48832b9049c0780ad977bb