### PR TITLE
Fix alt attribute defaults and update translation scripts

### DIFF
--- a/fabs/contact.html
+++ b/fabs/contact.html
@@ -225,6 +225,8 @@
           const val = el.getAttribute(`data-${lang}`);
           if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') {
             el.placeholder = val;
+          } else if (el.tagName === 'IMG') {
+            el.alt = val;
           } else if (el.tagName === 'OPTION') {
             el.textContent = val;
           } else {

--- a/fabs/join.html
+++ b/fabs/join.html
@@ -345,6 +345,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const val = el.getAttribute(`data-${lang}`);
       if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') {
         el.placeholder = val;
+      } else if (el.tagName === 'IMG') {
+        el.alt = val;
       } else if (el.tagName === 'OPTION') {
         el.textContent = val;
       } else {

--- a/services/business.html
+++ b/services/business.html
@@ -79,7 +79,7 @@
       “Within 60 days, we slashed internal admin time by 30%. Their team made our systems smarter, not just faster.”
     </blockquote>
     <strong data-en="– COO, TechCo" data-es="– Director de Operaciones, TechCo">– COO, TechCo</strong><br>
-    <img src="logos-clients.png" alt=""
+    <img src="logos-clients.png" alt="Trusted by Siemens, Deloitte, HubSpot"
          data-en="Trusted by Siemens, Deloitte, HubSpot"
          data-es="Con la confianza de Siemens, Deloitte, HubSpot"
          style="max-width:100%;">

--- a/services/contactcenter.html
+++ b/services/contactcenter.html
@@ -88,7 +88,7 @@
       </strong>
     </blockquote>
     <img src="client-logos.png"
-         alt=""
+         alt="Client logos"
          data-en="Client logos"
          data-es="Logotipos de clientes"
          style="max-width:100%;">

--- a/services/itsupport.html
+++ b/services/itsupport.html
@@ -84,7 +84,7 @@
       Certifications & Compliance
     </h2>
     <img src="security-certifications.png"
-         alt=""
+         alt="ISO, SOC2, HIPAA"
          data-en="ISO, SOC2, HIPAA"
          data-es="ISO, SOC2, HIPAA"
          style="max-width:100%;">

--- a/services/professionals.html
+++ b/services/professionals.html
@@ -70,7 +70,7 @@
       <strong data-en="– CEO, B2B SaaS" data-es="– CEO, SaaS B2B">– CEO, B2B SaaS</strong>
     </blockquote>
     <img src="partner-logos.png"
-         alt=""
+         alt="Client logos"
          data-en="Client logos"
          data-es="Logotipos de clientes"
          style="max-width:100%;">


### PR DESCRIPTION
## Summary
- set English alt text for images in services pages
- update language switching scripts in FABS pages to handle image alt attributes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68819ac32d7c832b856bbb034a0b239b