### PR TITLE
Improve chatbot backdrop close behavior

### DIFF
--- a/bot/app.js
+++ b/bot/app.js
@@ -52,12 +52,15 @@ themeCtrl.addEventListener('click', () => {
   themeCtrl.textContent = isDark ? 'Dark' : 'Light';
 });
 
-// Close handler with fallback
+// Close handler - notify parent
 closeCtrl.addEventListener('click', () => {
-  if (history.length > 1) history.back();
-  else window.location.href = '/';
+  window.parent.postMessage({ type: 'closeChatbot' }, '*');
 });
-window.addEventListener('keydown', e => { if (e.key === 'Escape') closeCtrl.click(); });
+window.addEventListener('keydown', e => {
+  if (e.key === 'Escape') {
+    window.parent.postMessage({ type: 'closeChatbot' }, '*');
+  }
+});
 
 /* === Chatbot Core === */
 const log          = qs('#chat-log');

--- a/css/global.css
+++ b/css/global.css
@@ -170,9 +170,20 @@ body {
     }
     body.dark .card .icon > i { filter: drop-shadow(0 0 2px #00c4ff55); }
     /* --- MODAL BASE --- */
-    .modal-backdrop {
+.modal-backdrop {
       position: fixed;
       z-index: 1999;
+      left: 0; top: 0; right: 0; bottom: 0;
+      background: rgba(44,26,73,0.31);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+}
+
+    /* Backdrop for floating chatbot */
+    #chatbot-wrapper {
+      position: fixed;
+      z-index: 2899;
       left: 0; top: 0; right: 0; bottom: 0;
       background: rgba(44,26,73,0.31);
       display: flex;
@@ -305,8 +316,8 @@ body {
       max-width: 490px;
       width: 96vw;
       height: 510px;
-      background: #fff;
-      color: #1a1930;
+      background: #251541;
+      color: #fafbfe;
       border-radius: 2rem;
       box-shadow: 0 6px 60px #5e24bb25, 0 0 0 2px #fff1;
       padding: 2.1rem 2.2rem 1.3rem 2.2rem;

--- a/js/main.js
+++ b/js/main.js
@@ -248,21 +248,37 @@
       window.location.href = 'fabs/join.html';
     }
     function openChatbot() {
-      let existing = document.getElementById('chatbot-container');
+      let existing = document.getElementById('chatbot-wrapper');
       if(existing){ existing.remove(); return; }
+      let wrapper = document.createElement('div');
+      wrapper.id = 'chatbot-wrapper';
+
       let chatbotCont = document.createElement('div');
       chatbotCont.id = "chatbot-container";
       chatbotCont.setAttribute('tabindex','-1');
       chatbotCont.setAttribute('role','dialog');
       chatbotCont.setAttribute('aria-modal','true');
       chatbotCont.innerHTML = `<iframe src="bot/chatbot.html" style="width:100%;height:100%;border:none;"></iframe>`;
-      document.body.appendChild(chatbotCont);
+      wrapper.appendChild(chatbotCont);
+      document.body.appendChild(wrapper);
+
       const iframe = chatbotCont.querySelector('iframe');
       iframe.addEventListener('load', () => {
         connector.emit('langChange', lang);
         connector.emit('themeChange', theme);
       });
-      document.addEventListener('keydown', function esc(e){if(e.key==="Escape"){chatbotCont.remove();document.removeEventListener('keydown',esc);}}, {once:true});
+
+      function close() {
+        wrapper.remove();
+        document.removeEventListener('keydown', esc);
+        window.removeEventListener('message', onMsg);
+      }
+      function esc(e){ if(e.key==="Escape") close(); }
+      document.addEventListener('keydown', esc);
+      wrapper.addEventListener('click', e => { if(e.target === wrapper) close(); });
+      function onMsg(e){ if(e.data && e.data.type === 'closeChatbot') close(); }
+      window.addEventListener('message', onMsg);
+
       makeDraggable(chatbotCont);
     }
 


### PR DESCRIPTION
## Summary
- style chatbot modal with darker theme
- add backdrop styles for chatbot wrapper
- allow iframe to request closing via message
- make wrapper/backdrop handle Escape or click-outside to close

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68819b2ab828832ba8c4c776799910e3