### PR TITLE
Improve alt text for service page images

### DIFF
--- a/services/business.html
+++ b/services/business.html
@@ -79,9 +79,9 @@
       “Within 60 days, we slashed internal admin time by 30%. Their team made our systems smarter, not just faster.”
     </blockquote>
     <strong data-en="– COO, TechCo" data-es="– Director de Operaciones, TechCo">– COO, TechCo</strong><br>
-    <img src="logos-clients.png" alt=""
-         data-en="Trusted by Siemens, Deloitte, HubSpot"
-         data-es="Con la confianza de Siemens, Deloitte, HubSpot"
+    <img src="logos-clients.png" alt="Logos of clients"
+         data-en="Logos of clients"
+         data-es="Logotipos de clientes"
          style="max-width:100%;">
   </section>
 

--- a/services/contactcenter.html
+++ b/services/contactcenter.html
@@ -88,8 +88,8 @@
       </strong>
     </blockquote>
     <img src="client-logos.png"
-         alt=""
-         data-en="Client logos"
+         alt="Logos of clients"
+         data-en="Logos of clients"
          data-es="Logotipos de clientes"
          style="max-width:100%;">
   </section>

--- a/services/itsupport.html
+++ b/services/itsupport.html
@@ -84,9 +84,9 @@
       Certifications & Compliance
     </h2>
     <img src="security-certifications.png"
-         alt=""
-         data-en="ISO, SOC2, HIPAA"
-         data-es="ISO, SOC2, HIPAA"
+         alt="Security certifications"
+         data-en="Security certifications"
+         data-es="Certificaciones de seguridad"
          style="max-width:100%;">
     <p data-en="Our team is certified in ISO 27001, SOC2, and HIPAA — ensuring secure, enterprise‑grade support."
        data-es="Nuestro equipo está certificado en ISO 27001, SOC2 y HIPAA — garantizando soporte seguro de calidad empresarial.">

--- a/services/professionals.html
+++ b/services/professionals.html
@@ -70,8 +70,8 @@
       <strong data-en="– CEO, B2B SaaS" data-es="– CEO, SaaS B2B">– CEO, B2B SaaS</strong>
     </blockquote>
     <img src="partner-logos.png"
-         alt=""
-         data-en="Client logos"
+         alt="Logos of clients"
+         data-en="Logos of clients"
          data-es="Logotipos de clientes"
          style="max-width:100%;">
   </section>


### PR DESCRIPTION
## Summary
- provide default alt text for logos and certifications
- let language toggle update the image alt text

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6881a150b95c832b8afd5dcd4cb5542f