### PR TITLE
Add strict origin checks for chatbot communication

### DIFF
--- a/bot/app.js
+++ b/bot/app.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// Expected parent origin
+const ALLOWED_ORIGIN = window.location.origin;
+
 // Short selectors
 const qs = s => document.querySelector(s);
 const qsa = s => document.querySelectorAll(s);
@@ -16,6 +19,7 @@ let curLang = 'en';
 let curTheme = 'light';
 
 window.addEventListener('message', event => {
+  if (event.origin !== ALLOWED_ORIGIN) return;
   if (event.data.type === 'langChange') {
     curLang = event.data.lang;
     const isEn = curLang === 'en';
@@ -35,7 +39,7 @@ window.addEventListener('message', event => {
 // Toggle controls and notify parent
 langCtrl.addEventListener('click', () => {
   curLang = curLang === 'en' ? 'es' : 'en';
-  window.parent.postMessage({ type: 'langChange', lang: curLang }, '*');
+  window.parent.postMessage({ type: 'langChange', lang: curLang }, ALLOWED_ORIGIN);
   const isEn = curLang === 'en';
   document.documentElement.lang = isEn ? 'en' : 'es';
   langCtrl.textContent = isEn ? 'EN' : 'ES';
@@ -46,7 +50,7 @@ langCtrl.addEventListener('click', () => {
 
 themeCtrl.addEventListener('click', () => {
   curTheme = curTheme === 'light' ? 'dark' : 'light';
-  window.parent.postMessage({ type: 'themeChange', theme: curTheme }, '*');
+  window.parent.postMessage({ type: 'themeChange', theme: curTheme }, ALLOWED_ORIGIN);
   const isDark = curTheme === 'dark';
   document.body.classList.toggle('dark', isDark);
   themeCtrl.textContent = isDark ? 'Dark' : 'Light';

--- a/js/connector.js
+++ b/js/connector.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// Expected origin for the chatbot iframe
+const ALLOWED_ORIGIN = window.location.origin;
+
 class EventEmitter {
     constructor() {
         if (EventEmitter.instance) {
@@ -28,13 +31,13 @@ const connector = new EventEmitter();
 connector.on('langChange', lang => {
   const iframe = document.querySelector('#chatbot-container iframe');
   if (iframe) {
-    iframe.contentWindow.postMessage({ type: 'langChange', lang }, '*');
+    iframe.contentWindow.postMessage({ type: 'langChange', lang }, ALLOWED_ORIGIN);
   }
 });
 
 connector.on('themeChange', theme => {
   const iframe = document.querySelector('#chatbot-container iframe');
   if (iframe) {
-    iframe.contentWindow.postMessage({ type: 'themeChange', theme }, '*');
+    iframe.contentWindow.postMessage({ type: 'themeChange', theme }, ALLOWED_ORIGIN);
   }
 });

--- a/js/main.js
+++ b/js/main.js
@@ -173,6 +173,7 @@
     };
     let lang = localStorage.getItem('ops-lang') || "en";
     let theme = localStorage.getItem('ops-theme') || "light";
+    const ALLOWED_ORIGIN = window.location.origin;
 
     document.documentElement.setAttribute('lang', lang);
 
@@ -305,6 +306,7 @@
 
     // Receive updates from chatbot iframe
     window.addEventListener('message', e => {
+      if(e.origin !== ALLOWED_ORIGIN) return;
       if(!e.data || !e.data.type) return;
       if(e.data.type === 'langChange' && e.data.lang) {
         if(e.data.lang !== lang) setLang(e.data.lang);


### PR DESCRIPTION
## Summary
- define `ALLOWED_ORIGIN` constant in front-end scripts
- send messages only to the allowed origin
- verify `event.origin` before handling messages in main site and chatbot

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6881a14d7150832baf2afa495304f98e