### PR TITLE
Improve headers and service worker security

### DIFF
--- a/bot/worker.js
+++ b/bot/worker.js
@@ -15,11 +15,14 @@ async function handleRequest(request) {
 
   const response = { reply }
 
-  return new Response(JSON.stringify(response), {
-    headers: {
-      'Content-Type': 'application/json',
-      // Limit CORS to the production domain for security
-      'Access-Control-Allow-Origin': 'https://example.com',
-    },
+  const headers = new Headers({
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': 'https://example.com',
+    'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload',
+    'X-Frame-Options': 'DENY',
+    'X-Content-Type-Options': 'nosniff',
+    'Referrer-Policy': 'same-origin'
   })
+
+  return new Response(JSON.stringify(response), { headers })
 }

--- a/sw.js
+++ b/sw.js
@@ -10,6 +10,7 @@ self.addEventListener('install', event => {
   );
 });
 self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
   event.respondWith(
     caches.match(event.request).then(response => {
       return response || fetch(event.request);


### PR DESCRIPTION
## Summary
- add common security response headers to the Cloudflare worker
- prevent non-GET requests from being cached in the service worker

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68819b31ed5c832bb3dcfd330b16203a