### PR TITLE
Implement offline fallback in service worker

### DIFF
--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Offline</title>
+  <link rel="stylesheet" href="css/global.css">
+</head>
+<body>
+  <h1>You are offline</h1>
+  <p>Sorry, the requested page is not available while you're offline.</p>
+</body>
+</html>

--- a/sw.js
+++ b/sw.js
@@ -1,18 +1,30 @@
-// Placeholder service worker with basic caching strategies
-const CACHE_NAME = 'ops-cache-v1';
+// Service worker with offline fallback and non-GET request bypass
+const CACHE_NAME = 'ops-cache-v2';
 const PRECACHE_URLS = [
   '/',
-  '/index.html'
+  '/index.html',
+  '/offline.html'
 ];
+
 self.addEventListener('install', event => {
   event.waitUntil(
     caches.open(CACHE_NAME).then(cache => cache.addAll(PRECACHE_URLS))
   );
 });
+
 self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') {
+    // Do not cache non-GET requests
+    event.respondWith(fetch(event.request));
+    return;
+  }
+
   event.respondWith(
-    caches.match(event.request).then(response => {
-      return response || fetch(event.request);
+    caches.match(event.request).then(cachedResponse => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+      return fetch(event.request).catch(() => caches.match('/offline.html'));
     })
   );
 });


### PR DESCRIPTION
## Summary
- precache an offline fallback page
- add offline.html for when cache and network are unavailable
- update service worker to bypass non-GET requests and supply the offline fallback

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881a5a925ac832b96b87fb3ed442a45