### PR TITLE
Add contact flow for service forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Neo Ops Website
+
+This repository contains the static files for the Neo Ops demo site. Each service page includes a simple lead form. Submitting these forms now routes the user to the main contact page and passes along the originating service.
+
+## Form Flow
+
+- Every service form has an `action` pointing to `fabs/contact.html`.
+- A hidden `service` field indicates which page the user came from.
+- `contact.html` reads this query parameter and pre-selects the corresponding option in the "interest" drop‑down.
+
+This makes it clear to the sales team which service the visitor was viewing before opening the contact form.

--- a/fabs/contact.html
+++ b/fabs/contact.html
@@ -190,10 +190,10 @@
         <label for="interest" data-en="What are you interested about?" data-es="¿Qué te interesa?">What are you interested about?</label>
         <select id="interest" required>
           <option value="" disabled selected>Select an option</option>
-          <option data-en="Business Operations" data-es="Operaciones Empresariales">Business Operations</option>
-          <option data-en="Contact Center" data-es="Centro de Contacto">Contact Center</option>
-          <option data-en="IT Support" data-es="Soporte Técnico">IT Support</option>
-          <option data-en="Professionals" data-es="Profesionales">Professionals</option>
+          <option value="Business Operations" data-en="Business Operations" data-es="Operaciones Empresariales">Business Operations</option>
+          <option value="Contact Center" data-en="Contact Center" data-es="Centro de Contacto">Contact Center</option>
+          <option value="IT Support" data-en="IT Support" data-es="Soporte Técnico">IT Support</option>
+          <option value="Professionals" data-en="Professionals" data-es="Profesionales">Professionals</option>
         </select>
       </div>
     </div>
@@ -219,6 +219,18 @@
 
       const langBtn = document.getElementById('langToggle');
       const themeBtn = document.getElementById('themeToggle');
+
+      // Preselect service from query string if provided
+      const params = new URLSearchParams(window.location.search);
+      const svc = params.get('service');
+      if (svc) {
+        const interestSelect = document.getElementById('interest');
+        const commentsField = document.getElementById('comments');
+        if (interestSelect) interestSelect.value = svc;
+        if (commentsField && !commentsField.value) {
+          commentsField.value = `Interested in ${svc}`;
+        }
+      }
 
       function updateLang(lang) {
         document.querySelectorAll('[data-en]').forEach(el => {

--- a/services/business.html
+++ b/services/business.html
@@ -90,7 +90,9 @@
     <h2 data-en="Book Your Free Audit" data-es="Reserve Su Auditoría Gratis">
       Book Your Free Audit
     </h2>
-    <form>
+    <!-- Redirects to main contact page with service context -->
+    <form action="../fabs/contact.html" method="get">
+      <input type="hidden" name="service" value="Business Operations">
       <input type="text"
              placeholder=""
              data-en="Your Name" data-es="Su Nombre"

--- a/services/contactcenter.html
+++ b/services/contactcenter.html
@@ -99,7 +99,9 @@
     <h2 data-en="See What We Can Do for You" data-es="Vea Lo Que Podemos Hacer por Usted">
       See What We Can Do for You
     </h2>
-    <form>
+    <!-- Redirects to main contact page with service context -->
+    <form action="../fabs/contact.html" method="get">
+      <input type="hidden" name="service" value="Contact Center">
       <input type="text"
              data-en="Full Name" data-es="Nombre Completo"
              placeholder="Full Name"

--- a/services/itsupport.html
+++ b/services/itsupport.html
@@ -99,7 +99,9 @@
     <h2 data-en="Request Your Free IT Readiness Check" data-es="Solicite Su Revisión Gratuita de Preparación TI">
       Request Your Free IT Readiness Check
     </h2>
-    <form>
+    <!-- Redirects to main contact page with service context -->
+    <form action="../fabs/contact.html" method="get">
+      <input type="hidden" name="service" value="IT Support">
       <input type="text"
              placeholder="Your Name"
              data-en="Your Name" data-es="Su Nombre"

--- a/services/professionals.html
+++ b/services/professionals.html
@@ -91,7 +91,9 @@
   <!-- Get Started Now -->
   <section id="form" style="padding-top:20px;">
     <h2 data-en="Get Started Now" data-es="Comience Ahora">Get Started Now</h2>
-    <form>
+    <!-- Redirects to main contact page with service context -->
+    <form action="../fabs/contact.html" method="get">
+      <input type="hidden" name="service" value="Professionals">
       <input type="text"
              placeholder="Full Name"
              data-en="Full Name"


### PR DESCRIPTION
## Summary
- send each service form to the main contact page
- include service context through a hidden field
- make `contact.html` pre-select the service
- document the new flow in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6881ff875730832b84d6a32f992a473b