### PR TITLE
Fix sitemap URL

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -9,7 +9,7 @@
   <url><loc>https://opsonlinesupport.com/modals/itsupport.html</loc></url>
   <url><loc>https://opsonlinesupport.com/modals/professionals.html</loc></url>
   <url><loc>https://opsonlinesupport.com/services/business.html</loc></url>
-  <url><loc>https:/opsonlinesupport.com/services/contactcenter.html</loc></url>
+  <url><loc>https://opsonlinesupport.com/services/contactcenter.html</loc></url>
   <url><loc>https://opsonlinesupport.com/services/itsupport.html</loc></url>
   <url><loc>https://opsonlinesupport.com/services/professionals.html</loc></url>
 </urlset>


### PR DESCRIPTION
## Summary
- fix incorrect URL in sitemap.xml

## Testing
- `python3 - <<'EOF'
import xml.etree.ElementTree as ET
import re
root=ET.parse('sitemap.xml').getroot()
for loc in root.findall('{http://www.sitemaps.org/schemas/sitemap/0.9}url/{http://www.sitemaps.org/schemas/sitemap/0.9}loc'):
    url=loc.text
    if not re.match(r'^https://[^\s]+$', url):
        print('Invalid URL', url)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688214f5081c832bb7d41ff734840b26