### PR TITLE
Add offline fallback support

### DIFF
--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Offline | OPS</title>
+  <link rel="stylesheet" href="css/global.css">
+  <link rel="stylesheet" href="css/adaptablescreens.css" media="(max-width: 900px)">
+</head>
+<body>
+  <div style="text-align:center; padding:2rem;">
+    <h1>You appear to be offline</h1>
+    <p>Please check your internet connection and try again.</p>
+  </div>
+</body>
+</html>

--- a/sw.js
+++ b/sw.js
@@ -1,18 +1,37 @@
-// Placeholder service worker with basic caching strategies
+// Service worker with offline fallback
 const CACHE_NAME = 'ops-cache-v1';
 const PRECACHE_URLS = [
   '/',
-  '/index.html'
+  '/index.html',
+  '/offline.html'
 ];
+
 self.addEventListener('install', event => {
   event.waitUntil(
     caches.open(CACHE_NAME).then(cache => cache.addAll(PRECACHE_URLS))
   );
 });
+
 self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+
+  const { origin } = new URL(event.request.url);
+  if (origin !== location.origin) {
+    event.respondWith(fetch(event.request));
+    return;
+  }
+
   event.respondWith(
-    caches.match(event.request).then(response => {
-      return response || fetch(event.request);
-    })
+    fetch(event.request)
+      .then(networkResponse => {
+        const responseClone = networkResponse.clone();
+        caches.open(CACHE_NAME).then(cache => cache.put(event.request, responseClone));
+        return networkResponse;
+      })
+      .catch(() => {
+        return caches.match(event.request).then(cached => {
+          return cached || caches.match('/offline.html');
+        });
+      })
   );
 });


### PR DESCRIPTION
## Summary
- add offline fallback HTML page
- update service worker to serve cached content with offline page when network fails

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688213426c88832bab026fede31aa997