### PR TITLE
Fix sitemap URL in robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https:/opsonlinesupport.com/sitemap.xml
+Sitemap: https://opsonlinesupport.com/sitemap.xml


### PR DESCRIPTION
## Summary
- fix robots.txt sitemap URL to use https://

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68821c085d94832bb4d49ff1afdd9ffe