### PR TITLE
Replace service forms with contact links

### DIFF
--- a/services/business.html
+++ b/services/business.html
@@ -90,21 +90,13 @@
     <h2 data-en="Book Your Free Audit" data-es="Reserve Su Auditoría Gratis">
       Book Your Free Audit
     </h2>
-    <form>
-      <input type="text"
-             placeholder=""
-             data-en="Your Name" data-es="Su Nombre"
-             required><br>
-      <input type="email"
-             placeholder=""
-             data-en="Your Email" data-es="Su Correo Electrónico"
-             required><br>
-      <button type="submit"
-              style="background:#007acc; color:#fff; padding:10px 20px; border:none; border-radius:5px;"
-              data-en="Schedule Now" data-es="Programar Ahora">
-        Schedule Now
-      </button>
-    </form>
+    <a href="../fabs/contact.html?service=business"
+       role="button"
+       aria-label="Schedule Now"
+       style="background:#007acc; color:#fff; padding:10px 20px; border:none; border-radius:5px; text-decoration:none; display:inline-block;"
+       data-en="Schedule Now" data-es="Programar Ahora">
+      Schedule Now
+    </a>
   </section>
 
   <script src="business.js"></script>

--- a/services/contactcenter.html
+++ b/services/contactcenter.html
@@ -99,25 +99,13 @@
     <h2 data-en="See What We Can Do for You" data-es="Vea Lo Que Podemos Hacer por Usted">
       See What We Can Do for You
     </h2>
-    <form>
-      <input type="text"
-             data-en="Full Name" data-es="Nombre Completo"
-             placeholder="Full Name"
-             required><br>
-      <input type="email"
-             data-en="Business Email" data-es="Correo Electrónico Empresarial"
-             placeholder="Business Email"
-             required><br>
-      <input type="text"
-             data-en="Company" data-es="Empresa"
-             placeholder="Company"
-             required><br>
-      <button type="submit"
-              style="background:#007acc; color:white; padding:10px 20px; border:none; border-radius:5px;"
-              data-en="Request Quote" data-es="Solicitar Cotización">
-        Request Quote
-      </button>
-    </form>
+    <a href="../fabs/contact.html?service=contactcenter"
+       role="button"
+       aria-label="Request Quote"
+       style="background:#007acc; color:white; padding:10px 20px; border:none; border-radius:5px; text-decoration:none; display:inline-block;"
+       data-en="Request Quote" data-es="Solicitar Cotización">
+      Request Quote
+    </a>
   </section>
 
   <script src="contact.js"></script>

--- a/services/itsupport.html
+++ b/services/itsupport.html
@@ -99,25 +99,13 @@
     <h2 data-en="Request Your Free IT Readiness Check" data-es="Solicite Su Revisión Gratuita de Preparación TI">
       Request Your Free IT Readiness Check
     </h2>
-    <form>
-      <input type="text"
-             placeholder="Your Name"
-             data-en="Your Name" data-es="Su Nombre"
-             required><br>
-      <input type="email"
-             placeholder="Work Email"
-             data-en="Work Email" data-es="Correo Electrónico Laboral"
-             required><br>
-      <input type="text"
-             placeholder="Company Size"
-             data-en="Company Size" data-es="Tamaño de la Empresa"
-             required><br>
-      <button type="submit"
-              style="background:#007acc; color:white; padding:10px 20px; border:none; border-radius:5px;"
-              data-en="Request Now" data-es="Solicitar Ahora">
-        Request Now
-      </button>
-    </form>
+    <a href="../fabs/contact.html?service=itsupport"
+       role="button"
+       aria-label="Request Now"
+       style="background:#007acc; color:white; padding:10px 20px; border:none; border-radius:5px; text-decoration:none; display:inline-block;"
+       data-en="Request Now" data-es="Solicitar Ahora">
+      Request Now
+    </a>
   </section>
 
   <script src="itsupport.js"></script>

--- a/services/professionals.html
+++ b/services/professionals.html
@@ -91,24 +91,14 @@
   <!-- Get Started Now -->
   <section id="form" style="padding-top:20px;">
     <h2 data-en="Get Started Now" data-es="Comience Ahora">Get Started Now</h2>
-    <form>
-      <input type="text"
-             placeholder="Full Name"
-             data-en="Full Name"
-             data-es="Nombre Completo"
-             required><br>
-      <input type="email"
-             placeholder="Business Email"
-             data-en="Business Email"
-             data-es="Correo Electrónico Empresarial"
-             required><br>
-      <button type="submit"
-              style="background:#007acc; color:#fff; padding:10px 20px; border:none; border-radius:5px;"
-              data-en="Book Session"
-              data-es="Reservar Sesión">
-        Book Session
-      </button>
-    </form>
+    <a href="../fabs/contact.html?service=professionals"
+       role="button"
+       aria-label="Book Session"
+       style="background:#007acc; color:#fff; padding:10px 20px; border:none; border-radius:5px; text-decoration:none; display:inline-block;"
+       data-en="Book Session"
+       data-es="Reservar Sesión">
+      Book Session
+    </a>
   </section>
 
   <script src="professionals.js"></script>


### PR DESCRIPTION
## Summary
- update Business, Contact Center, IT Support and Professionals pages
- replace inline forms with contact page links styled as buttons

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688214e04244832baac8bf8cc1d2171e