### PR TITLE
Improve service worker asset caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {
-        navigator.serviceWorker.register('/sw.js');
+        navigator.serviceWorker.register('/sw.js?v=2');
       });
     }
   </script>

--- a/sw.js
+++ b/sw.js
@@ -1,18 +1,47 @@
-// Placeholder service worker with basic caching strategies
-const CACHE_NAME = 'ops-cache-v1';
+// Service worker with pre-caching and cache versioning
+const CACHE_VERSION = 'v2';
+const CACHE_NAME = `ops-cache-${CACHE_VERSION}`;
 const PRECACHE_URLS = [
   '/',
-  '/index.html'
+  '/index.html',
+  '/manifest.json',
+  '/css/global.css',
+  '/css/adaptablescreens.css',
+  '/js/main.js',
+  '/js/connector.js',
+  '/js/langthem.js',
+  '/services/business.html',
+  '/services/contactcenter.html',
+  '/services/itsupport.html',
+  '/services/professionals.html',
+  '/modals/businessoperations.html',
+  '/modals/contactcenter.html',
+  '/modals/itsupport.html',
+  '/modals/professionals.html',
+  '/fabs/contact.html',
+  '/fabs/join.html',
+  '/bot/chatbot.html',
+  '/bot/style.css',
+  '/bot/app.js',
+  '/bot/worker.js'
 ];
 self.addEventListener('install', event => {
   event.waitUntil(
     caches.open(CACHE_NAME).then(cache => cache.addAll(PRECACHE_URLS))
   );
 });
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(names => {
+      return Promise.all(
+        names.filter(name => name.startsWith('ops-cache-') && name !== CACHE_NAME)
+             .map(name => caches.delete(name))
+      );
+    })
+  );
+});
 self.addEventListener('fetch', event => {
   event.respondWith(
-    caches.match(event.request).then(response => {
-      return response || fetch(event.request);
-    })
+    caches.match(event.request).then(response => response || fetch(event.request))
   );
 });


### PR DESCRIPTION
## Summary
- precache js, css, and html assets
- add cache versioning and cleanup logic
- register service worker with version parameter

## Testing
- `python3 -m http.server 8000`
- `curl -I http://localhost:8000/index.html`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68821cd7eed8832b9125b3de99e91647