### PR TITLE
Fix chatbot control duplication and add close button

### DIFF
--- a/bot/app.js
+++ b/bot/app.js
@@ -1,17 +1,13 @@
 const qs=s=>document.querySelector(s),
       qsa=s=>[...document.querySelectorAll(s)];
 
-/* === Language toggle === */
+/* === Language & Theme Controls === */
 const langCtrl   = qs('#langCtrl'),
       transNodes = qsa('[data-en]'),
       phNodes    = qsa('[data-en-ph]'),
-      humanLab   = qs('#human-label');
-
-/* === Transliteration & Theme Controls === */
-const langCtrl   = qs('#langCtrl');
-const humanLab   = qs('#human-label');
-const closeCtrl  = qs('#closeCtrl');
-const themeCtrl  = qs('#themeCtrl');
+      humanLab   = qs('#human-label'),
+      closeCtrl  = qs('#closeCtrl'),
+      themeCtrl  = qs('#themeCtrl');
 
 let curLang = 'en';
 let curTheme = 'light';

--- a/bot/chatbot.html
+++ b/bot/chatbot.html
@@ -19,6 +19,8 @@
       <span id="langCtrl" class="ctrl">ES</span>
       &nbsp;|&nbsp;
       <span id="themeCtrl" class="ctrl">Dark</span>
+      &nbsp;|&nbsp;
+      <span id="closeCtrl" class="ctrl" aria-label="Close">&times;</span>
     </div>
   </div>
   <div id="chat-log" aria-live="polite"></div>


### PR DESCRIPTION
## Summary
- remove duplicate `langCtrl` and `humanLab` declarations
- add a close button to the chatbot header

## Testing
- `npm test` *(fails: no test specified)*
- `npm install jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68821c1470c0832b83dacae562c86be4