### PR TITLE
Add language attributes to modal pages

### DIFF
--- a/modals/businessoperations.html
+++ b/modals/businessoperations.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Business Operations - OPS Modal</title>
+<title data-en="Business Operations - OPS Modal" data-es="Operaciones Empresariales - Modal de OPS">Business Operations - OPS Modal</title>
 <link
   rel="stylesheet"
   href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
@@ -145,25 +145,25 @@
     <div class="ops-modal" tabindex="0">
       <button class="modal-x" aria-label="Close modal">&times;</button>
       <div class="modal-header" id="modal-title">
-        <img class="modal-img" src="https://placehold.co/96x96?text=OPS" alt="Business Operations" />
-        <div><div class="modal-title">BUSINESS OPERATIONS</div></div>
+        <img class="modal-img" src="https://placehold.co/96x96?text=OPS" alt="Business Operations" data-en="Business Operations" data-es="Operaciones Empresariales" />
+        <div><div class="modal-title" data-en="BUSINESS OPERATIONS" data-es="OPERACIONES EMPRESARIALES">BUSINESS OPERATIONS</div></div>
       </div>
-      <div class="modal-content-body">
+      <div class="modal-content-body" data-en="Detailed content about our Business Operations services. We help optimize your processes, boost efficiency, and drive growth through strategic operational support. Key areas: process optimization, supply chain management, quality assurance." data-es="Contenido detallado sobre nuestros servicios de Operaciones Empresariales. Ayudamos a optimizar sus procesos, aumentar la eficiencia y fomentar el crecimiento mediante soporte operativo estratégico. Áreas clave: optimización de procesos, gestión de la cadena de suministro, aseguramiento de la calidad.">
         Detailed content about our Business Operations services. We help optimize your processes, boost efficiency, and drive growth through strategic operational support. Key areas: process optimization, supply chain management, quality assurance.
       </div>
-      <div class="modal-video">Video placeholder</div>
+      <div class="modal-video" data-en="Video placeholder" data-es="Marcador de video">Video placeholder</div>
       <ul>
-        <li>Workflow digitization & automation</li>
-        <li>Logistics & inventory efficiency</li>
-        <li>Risk & compliance frameworks (NIST, ISO, CISA)</li>
-        <li>Performance metric dashboards & analytics</li>
-        <li>Remote training & Lean operations</li>
+        <li data-en="Workflow digitization & automation" data-es="Digitalización y automatización del flujo de trabajo">Workflow digitization & automation</li>
+        <li data-en="Logistics & inventory efficiency" data-es="Eficiencia logística y de inventario">Logistics & inventory efficiency</li>
+        <li data-en="Risk & compliance frameworks (NIST, ISO, CISA)" data-es="Marcos de riesgo y cumplimiento (NIST, ISO, CISA)">Risk & compliance frameworks (NIST, ISO, CISA)</li>
+        <li data-en="Performance metric dashboards & analytics" data-es="Tableros de métricas de rendimiento y analíticas">Performance metric dashboards & analytics</li>
+        <li data-en="Remote training & Lean operations" data-es="Capacitación remota y operaciones Lean">Remote training & Lean operations</li>
       </ul>
       <div class="modal-actions">
-        <a class="modal-btn" href="../services/business.html" target="_blank" rel="noopener noreferrer">Learn More</a>
-        <button class="modal-btn" id="ask-chattia-btn">Ask Chattia</button>
-        <button class="modal-btn cta" id="contact-us-btn"><i class="fa fa-envelope" aria-hidden="true"></i> Contact Us</button>
-        <button class="modal-btn cancel-btn">Cancel</button>
+        <a class="modal-btn" href="../services/business.html" target="_blank" rel="noopener noreferrer" data-en="Learn More" data-es="Más Información">Learn More</a>
+        <button class="modal-btn" id="ask-chattia-btn" data-en="Ask Chattia" data-es="Preguntar a Chattia">Ask Chattia</button>
+        <button class="modal-btn cta" id="contact-us-btn"><i class="fa fa-envelope" aria-hidden="true"></i> <span data-en="Contact Us" data-es="Contáctanos">Contact Us</span></button>
+        <button class="modal-btn cancel-btn" data-en="Cancel" data-es="Cancelar">Cancel</button>
       </div>
     </div>
   </div>
@@ -236,8 +236,16 @@
       };
     }
 
-    makeDraggable(modal, modal.querySelector('.modal-header'));
-  })();
+  makeDraggable(modal, modal.querySelector('.modal-header'));
+})();
+</script>
+<script src="../js/langthem.js"></script>
+<script>
+  const lang = localStorage.getItem('ops-lang') || 'en';
+  updateLanguage(lang);
+  window.addEventListener('storage', e => {
+    if (e.key === 'ops-lang') updateLanguage(e.newValue);
+  });
 </script>
 </body>
 </html>

--- a/modals/contactcenter.html
+++ b/modals/contactcenter.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Contact Center - OPS Modal</title>
+<title data-en="Contact Center - OPS Modal" data-es="Centro de Contacto - Modal de OPS">Contact Center - OPS Modal</title>
 <link
   rel="stylesheet"
   href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
@@ -145,25 +145,25 @@
     <div class="ops-modal" tabindex="0">
       <button class="modal-x" aria-label="Close modal">&times;</button>
       <div class="modal-header" id="modal-title">
-        <img class="modal-img" src="https://placehold.co/96x96?text=CC" alt="Contact Center" />
-        <div><div class="modal-title">CONTACT CENTER</div></div>
+        <img class="modal-img" src="https://placehold.co/96x96?text=CC" alt="Contact Center" data-en="Contact Center" data-es="Centro de Contacto" />
+        <div><div class="modal-title" data-en="CONTACT CENTER" data-es="CENTRO DE CONTACTO">CONTACT CENTER</div></div>
       </div>
-      <div class="modal-content-body">
+      <div class="modal-content-body" data-en="Explore our comprehensive Contact Center solutions to elevate customer satisfaction and engagement at every touchpoint. We offer inbound/outbound calls, multichannel support (email, chat, social), and advanced analytics." data-es="Explore nuestras soluciones integrales de Centro de Contacto para elevar la satisfacción del cliente y la participación en cada punto de contacto. Ofrecemos llamadas entrantes/salientes, soporte multicanal (email, chat, redes sociales) y analíticas avanzadas.">
         Explore our comprehensive Contact Center solutions to elevate customer satisfaction and engagement at every touchpoint. We offer inbound/outbound calls, multichannel support (email, chat, social), and advanced analytics.
       </div>
-      <div class="modal-video">Video placeholder</div>
+      <div class="modal-video" data-en="Video placeholder" data-es="Marcador de video">Video placeholder</div>
       <ul>
-        <li>24/7 inbound/outbound call management</li>
-        <li>Multilingual chat/email support</li>
-        <li>CRM integration (e.g., HubSpot, Salesforce)</li>
-        <li>Social media engagement & sentiment tracking</li>
-        <li>Customer experience analytics & quality monitoring</li>
+        <li data-en="24/7 inbound/outbound call management" data-es="Gestión de llamadas entrantes y salientes 24/7">24/7 inbound/outbound call management</li>
+        <li data-en="Multilingual chat/email support" data-es="Soporte de chat/correo multilingüe">Multilingual chat/email support</li>
+        <li data-en="CRM integration (e.g., HubSpot, Salesforce)" data-es="Integración con CRM (por ejemplo, HubSpot, Salesforce)">CRM integration (e.g., HubSpot, Salesforce)</li>
+        <li data-en="Social media engagement & sentiment tracking" data-es="Participación en redes sociales y seguimiento de sentimiento">Social media engagement & sentiment tracking</li>
+        <li data-en="Customer experience analytics & quality monitoring" data-es="Analítica de experiencia del cliente y monitoreo de calidad">Customer experience analytics & quality monitoring</li>
       </ul>
       <div class="modal-actions">
-        <a class="modal-btn" href="../services/contactcenter.html" target="_blank" rel="noopener noreferrer">Learn More</a>
-        <button class="modal-btn" id="ask-chattia-btn">Ask Chattia</button>
-        <button class="modal-btn cta" id="contact-us-btn"><i class="fa fa-envelope" aria-hidden="true"></i> Contact Us</button>
-        <button class="modal-btn cancel-btn">Cancel</button>
+        <a class="modal-btn" href="../services/contactcenter.html" target="_blank" rel="noopener noreferrer" data-en="Learn More" data-es="Más Información">Learn More</a>
+        <button class="modal-btn" id="ask-chattia-btn" data-en="Ask Chattia" data-es="Preguntar a Chattia">Ask Chattia</button>
+        <button class="modal-btn cta" id="contact-us-btn"><i class="fa fa-envelope" aria-hidden="true"></i> <span data-en="Contact Us" data-es="Contáctanos">Contact Us</span></button>
+        <button class="modal-btn cancel-btn" data-en="Cancel" data-es="Cancelar">Cancel</button>
       </div>
     </div>
   </div>
@@ -229,8 +229,16 @@
       };
     }
 
-    makeDraggable(modal, modal.querySelector('.modal-header'));
-  })();
+  makeDraggable(modal, modal.querySelector('.modal-header'));
+})();
+</script>
+<script src="../js/langthem.js"></script>
+<script>
+  const lang = localStorage.getItem('ops-lang') || 'en';
+  updateLanguage(lang);
+  window.addEventListener('storage', e => {
+    if (e.key === 'ops-lang') updateLanguage(e.newValue);
+  });
 </script>
 </body>
 </html>

--- a/modals/itsupport.html
+++ b/modals/itsupport.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>IT Support - OPS Modal</title>
+<title data-en="IT Support - OPS Modal" data-es="Soporte de TI - Modal de OPS">IT Support - OPS Modal</title>
 <link
   rel="stylesheet"
   href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
@@ -145,25 +145,25 @@
     <div class="ops-modal" tabindex="0">
       <button class="modal-x" aria-label="Close modal">&times;</button>
       <div class="modal-header" id="modal-title">
-        <img class="modal-img" src="https://placehold.co/96x96?text=IT" alt="IT Support" />
-        <div><div class="modal-title">IT SUPPORT</div></div>
+        <img class="modal-img" src="https://placehold.co/96x96?text=IT" alt="IT Support" data-en="IT Support" data-es="Soporte de TI" />
+        <div><div class="modal-title" data-en="IT SUPPORT" data-es="SOPORTE DE TI">IT SUPPORT</div></div>
       </div>
-      <div class="modal-content-body">
+      <div class="modal-content-body" data-en="Our IT Support services deliver reliable, timely assistance to keep your systems running smoothly and securely: help desk, network monitoring, cybersecurity, and cloud infrastructure management." data-es="Nuestros servicios de Soporte de TI brindan asistencia confiable y oportuna para mantener sus sistemas funcionando de forma segura: mesa de ayuda, monitoreo de redes, ciberseguridad y administración de infraestructura en la nube.">
         Our IT Support services deliver reliable, timely assistance to keep your systems running smoothly and securely: help desk, network monitoring, cybersecurity, and cloud infrastructure management.
       </div>
-      <div class="modal-video">Video placeholder</div>
+      <div class="modal-video" data-en="Video placeholder" data-es="Marcador de video">Video placeholder</div>
       <ul>
-        <li>24/7 tech support & remote troubleshooting</li>
-        <li>Real-time network & system monitoring</li>
-        <li>Cybersecurity audits, patching, threat detection</li>
-        <li>Cloud infrastructure setup & maintenance</li>
-        <li>NIST, CISA, OPS Core CyberSec compliance</li>
+        <li data-en="24/7 tech support & remote troubleshooting" data-es="Soporte técnico 24/7 y resolución remota">24/7 tech support & remote troubleshooting</li>
+        <li data-en="Real-time network & system monitoring" data-es="Monitoreo de red y sistemas en tiempo real">Real-time network & system monitoring</li>
+        <li data-en="Cybersecurity audits, patching, threat detection" data-es="Auditorías de ciberseguridad, parches y detección de amenazas">Cybersecurity audits, patching, threat detection</li>
+        <li data-en="Cloud infrastructure setup & maintenance" data-es="Configuración y mantenimiento de infraestructura en la nube">Cloud infrastructure setup & maintenance</li>
+        <li data-en="NIST, CISA, OPS Core CyberSec compliance" data-es="Cumplimiento de NIST, CISA y OPS Core CyberSec">NIST, CISA, OPS Core CyberSec compliance</li>
       </ul>
       <div class="modal-actions">
-        <a class="modal-btn" href="../services/itsupport.html" target="_blank" rel="noopener noreferrer">Learn More</a>
-        <button class="modal-btn" id="ask-chattia-btn">Ask Chattia</button>
-        <button class="modal-btn cta" id="contact-us-btn"><i class="fa fa-envelope" aria-hidden="true"></i> Contact Us</button>
-        <button class="modal-btn cancel-btn">Cancel</button>
+        <a class="modal-btn" href="../services/itsupport.html" target="_blank" rel="noopener noreferrer" data-en="Learn More" data-es="Más Información">Learn More</a>
+        <button class="modal-btn" id="ask-chattia-btn" data-en="Ask Chattia" data-es="Preguntar a Chattia">Ask Chattia</button>
+        <button class="modal-btn cta" id="contact-us-btn"><i class="fa fa-envelope" aria-hidden="true"></i> <span data-en="Contact Us" data-es="Contáctanos">Contact Us</span></button>
+        <button class="modal-btn cancel-btn" data-en="Cancel" data-es="Cancelar">Cancel</button>
       </div>
     </div>
   </div>
@@ -229,8 +229,16 @@
       };
     }
 
-    makeDraggable(modal, modal.querySelector('.modal-header'));
-  })();
+  makeDraggable(modal, modal.querySelector('.modal-header'));
+})();
+</script>
+<script src="../js/langthem.js"></script>
+<script>
+  const lang = localStorage.getItem('ops-lang') || 'en';
+  updateLanguage(lang);
+  window.addEventListener('storage', e => {
+    if (e.key === 'ops-lang') updateLanguage(e.newValue);
+  });
 </script>
 </body>
 </html>

--- a/modals/professionals.html
+++ b/modals/professionals.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Professionals - OPS Modal</title>
+<title data-en="Professionals - OPS Modal" data-es="Profesionales - Modal de OPS">Professionals - OPS Modal</title>
 <link
   rel="stylesheet"
   href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
@@ -145,26 +145,26 @@
     <div class="ops-modal" tabindex="0">
       <button class="modal-x" aria-label="Close modal">&times;</button>
       <div class="modal-header" id="modal-title">
-        <img class="modal-img" src="https://placehold.co/96x96?text=PRO" alt="Professionals" />
-        <div><div class="modal-title">PROFESSIONALS</div></div>
+        <img class="modal-img" src="https://placehold.co/96x96?text=PRO" alt="Professionals" data-en="Professionals" data-es="Profesionales" />
+        <div><div class="modal-title" data-en="PROFESSIONALS" data-es="PROFESIONALES">PROFESSIONALS</div></div>
       </div>
-      <div class="modal-content-body">
+      <div class="modal-content-body" data-en="Access our network of highly qualified and experienced professionals for your project or long-term staffing. Experts in IT, project management, finance, HR. OPS-vetted, NDA, compliance trained." data-es="Acceda a nuestra red de profesionales altamente calificados y experimentados para su proyecto o personal a largo plazo. Expertos en TI, gestión de proyectos, finanzas y RR. HH. Validados por OPS, bajo NDA y con capacitación en cumplimiento.">
         Access our network of highly qualified and experienced professionals for your project or long-term staffing. Experts in IT, project management, finance, HR. OPS-vetted, NDA, compliance trained.
       </div>
-      <div class="modal-video">Video placeholder</div>
+      <div class="modal-video" data-en="Video placeholder" data-es="Marcador de video">Video placeholder</div>
       <ul>
-        <li>Remote IT professionals (SysAdmins, DevOps, Analysts)</li>
-        <li>Project managers & agile consultants</li>
-        <li>Finance and accounting professionals</li>
-        <li>HR and recruitment experts</li>
-        <li>OPS-vetted talent with NDA, compliance and role-specific training</li>
-        <li>Ask AI</li>
+        <li data-en="Remote IT professionals (SysAdmins, DevOps, Analysts)" data-es="Profesionales de TI remotos (SysAdmins, DevOps, Analistas)">Remote IT professionals (SysAdmins, DevOps, Analysts)</li>
+        <li data-en="Project managers & agile consultants" data-es="Gerentes de proyecto y consultores ágiles">Project managers & agile consultants</li>
+        <li data-en="Finance and accounting professionals" data-es="Profesionales de finanzas y contabilidad">Finance and accounting professionals</li>
+        <li data-en="HR and recruitment experts" data-es="Expertos en RR. HH. y reclutamiento">HR and recruitment experts</li>
+        <li data-en="OPS-vetted talent with NDA, compliance and role-specific training" data-es="Talento validado por OPS con NDA, cumplimiento y capacitación específica">OPS-vetted talent with NDA, compliance and role-specific training</li>
+        <li data-en="Ask AI" data-es="Preguntar a la IA">Ask AI</li>
       </ul>
       <div class="modal-actions">
-        <a class="modal-btn" href="../services/professionals.html" target="_blank" rel="noopener noreferrer">Learn More</a>
-        <button class="modal-btn" id="ask-chattia-btn">Ask Chattia</button>
-        <button class="modal-btn cta" id="contact-us-btn"><i class="fa fa-envelope" aria-hidden="true"></i> Contact Us</button>
-        <button class="modal-btn cancel-btn">Cancel</button>
+        <a class="modal-btn" href="../services/professionals.html" target="_blank" rel="noopener noreferrer" data-en="Learn More" data-es="Más Información">Learn More</a>
+        <button class="modal-btn" id="ask-chattia-btn" data-en="Ask Chattia" data-es="Preguntar a Chattia">Ask Chattia</button>
+        <button class="modal-btn cta" id="contact-us-btn"><i class="fa fa-envelope" aria-hidden="true"></i> <span data-en="Contact Us" data-es="Contáctanos">Contact Us</span></button>
+        <button class="modal-btn cancel-btn" data-en="Cancel" data-es="Cancelar">Cancel</button>
       </div>
     </div>
   </div>
@@ -230,8 +230,16 @@
       };
     }
 
-    makeDraggable(modal, modal.querySelector('.modal-header'));
-  })();
+  makeDraggable(modal, modal.querySelector('.modal-header'));
+})();
+</script>
+<script src="../js/langthem.js"></script>
+<script>
+  const lang = localStorage.getItem('ops-lang') || 'en';
+  updateLanguage(lang);
+  window.addEventListener('storage', e => {
+    if (e.key === 'ops-lang') updateLanguage(e.newValue);
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add data-en/data-es translations for all modal text
- include language initialization script

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688221a7c564832ba160cf0ec4e7c934