### PR TITLE
Fix service card links

### DIFF
--- a/index.html
+++ b/index.html
@@ -514,7 +514,7 @@
               "Performance metric dashboards & analytics",
               "Remote training & Lean operations"
             ],
-            learn: "business-operations.html"
+            learn: "services/gestion.html"
           }
         },
         es: {
@@ -534,7 +534,7 @@
               "Cuadros de métricas de rendimiento y análisis",
               "Capacitación remota y operaciones Lean"
             ],
-            learn: "business-operations.html"
+            learn: "services/gestion.html"
           }
         }
       },
@@ -556,7 +556,7 @@
               "Social media engagement & sentiment tracking",
               "Customer experience analytics & quality monitoring"
             ],
-            learn: "contactcenter.html"
+            learn: "services/center.html"
           }
         },
         es: {
@@ -576,7 +576,7 @@
               "Interacción en redes sociales y seguimiento de sentimiento",
               "Análisis de experiencia del cliente y monitoreo de calidad"
             ],
-            learn: "contactcenter.html"
+            learn: "services/center.html"
           }
         }
       },
@@ -598,7 +598,7 @@
               "Cloud infrastructure setup & maintenance",
               "NIST, CISA, OPS Core CyberSec compliance"
             ],
-            learn: "itsupport.html"
+            learn: "services/it.html"
           }
         },
         es: {
@@ -618,7 +618,7 @@
               "Configuración y mantenimiento de infraestructura en la nube",
               "Cumplimiento con NIST, CISA y políticas OPS Core CyberSec"
             ],
-            learn: "itsupport.html"
+            learn: "services/it.html"
           }
         }
       },
@@ -641,7 +641,7 @@
               "OPS-vetted talent with NDA, compliance and role-specific training",
               "Ask AI"
             ],
-            learn: "professionals.html"
+            learn: "services/pros.html"
           }
         },
         es: {
@@ -662,7 +662,7 @@
               "Talento validado por OPS con NDA, capacitación en cumplimiento y capacitación específica para el rol",
               "Preguntar AI"
             ],
-            learn: "professionals.html"
+            learn: "services/pros.html"
           }
         }
       }


### PR DESCRIPTION
## Summary
- update service card `learn` links to new location under `/services`

## Testing
- `grep -n services *.html`

------
https://chatgpt.com/codex/tasks/task_e_6884e914a5d8832b9d68bc75f9e81449