### PR TITLE
Fix duplicate robots meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
   <meta http-equiv="X-Frame-Options" content="DENY">
   <meta http-equiv="Strict-Transport-Security" content="max-age=31536000; includeSubDomains">
   <title>OPS Unified Portal</title>
-  <meta name="robots" content="index,follow">
   <link rel="sitemap" type="application/xml" href="/sitemap.xml">
   <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v6.0.0-beta1/css/all.css">
   <style>


### PR DESCRIPTION
## Summary
- remove extra `meta name="robots"` tag from index page

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688542af13f4832ba84e3c16b780ea2f