### PR TITLE
Update form handler endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,15 @@ JavaScript global.
 With the endpoint configured, the chatbot will POST user messages to your
 serverless function and display the returned `reply` text.
 
+## Contact Forms
+
+Service pages contain contact forms handled by `js/form-handler.js`. By default,
+the script submits form data to `https://example.com/api/form`. Set a custom
+target by defining the `FORM_ENDPOINT` global at runtime:
+
+```html
+<script>window.FORM_ENDPOINT = 'https://your-backend.example.com/form';</script>
+```
+
+When present, all service forms will POST their data to this endpoint.
+

--- a/js/form-handler.js
+++ b/js/form-handler.js
@@ -1,4 +1,5 @@
 document.addEventListener('DOMContentLoaded', () => {
+  const ENDPOINT = window.FORM_ENDPOINT || 'https://example.com/api/form';
   const forms = document.querySelectorAll('.service-form');
 
   forms.forEach(form => {
@@ -22,7 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
       try {
-        const res = await fetch('https://example.com/api/form', {
+        const res = await fetch(ENDPOINT, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(data)


### PR DESCRIPTION
## Summary
- make the form submission URL configurable via `FORM_ENDPOINT`
- document the new `FORM_ENDPOINT` variable in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688542c09dc8832b8ac28e2138a0f6e4