### PR TITLE
Add names to service form inputs

### DIFF
--- a/services/center.html
+++ b/services/center.html
@@ -396,21 +396,21 @@
     <h2 data-en="See What We Can Do for You" data-es="Vea Lo Que Podemos Hacer por Usted">See What We Can Do for You</h2>
     <form class="service-form">
       <input
-        type="text"
+        type="text" name="full_name"
         placeholder=""
         data-en="Full Name"
         data-es="Nombre Completo"
         required
       />
       <input
-        type="email"
+        type="email" name="email"
         placeholder=""
         data-en="Business Email"
         data-es="Correo Electrónico Empresarial"
         required
       />
       <input
-        type="text"
+        type="text" name="company"
         placeholder=""
         data-en="Company"
         data-es="Empresa"

--- a/services/gestion.html
+++ b/services/gestion.html
@@ -495,11 +495,11 @@
       Book Your Free Audit
     </h2>
     <form class="service-form">
-      <input type="text"
+      <input type="text" name="name"
              placeholder=""
              data-en="Your Name" data-es="Su Nombre"
              required />
-      <input type="email"
+      <input type="email" name="email"
              placeholder=""
              data-en="Your Email" data-es="Su Correo Electrónico"
              required />

--- a/services/it.html
+++ b/services/it.html
@@ -392,9 +392,9 @@
   <section id="form">
     <h2 data-en="Request Your Free IT Readiness Check" data-es="Solicite Su Revisión Gratuita de Preparación TI">Request Your Free IT Readiness Check</h2>
     <form class="service-form">
-      <input type="text" placeholder="" data-en="Your Name" data-es="Su Nombre" required />
-      <input type="email" placeholder="" data-en="Work Email" data-es="Correo Electrónico Laboral" required />
-      <input type="text" placeholder="" data-en="Company Size" data-es="Tamaño de la Empresa" required />
+      <input type="text" name="name" placeholder="" data-en="Your Name" data-es="Su Nombre" required />
+      <input type="email" name="email" placeholder="" data-en="Work Email" data-es="Correo Electrónico Laboral" required />
+      <input type="text" name="company_size" placeholder="" data-en="Company Size" data-es="Tamaño de la Empresa" required />
       <button type="submit" data-en="Request Now" data-es="Solicitar Ahora">Request Now</button>
     </form>
     <div class="form-message" aria-live="polite"></div>

--- a/services/pros.html
+++ b/services/pros.html
@@ -369,12 +369,12 @@
   <section id="form">
     <h2 data-en="Get Started Now" data-es="Comience Ahora">Get Started Now</h2>
     <form class="service-form">
-      <input type="text"
+      <input type="text" name="full_name"
              placeholder=""
              data-en="Full Name"
              data-es="Nombre Completo"
              required />
-      <input type="email"
+      <input type="email" name="email"
              placeholder=""
              data-en="Business Email"
              data-es="Correo Electrónico Empresarial"


### PR DESCRIPTION
## Summary
- provide `name` attributes for all `.service-form` inputs

## Testing
- `npm test` *(fails: Could not read package.json)*
- `html5validator --root .` *(fails: html5validator not installed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688542ca4e90832b8a42096d12ece74e